### PR TITLE
수동 매치 개발

### DIFF
--- a/src/main/java/com/fofo/core/controller/MatchController.java
+++ b/src/main/java/com/fofo/core/controller/MatchController.java
@@ -58,7 +58,7 @@ public class MatchController {
     @Operation(summary = "전체 or 선택 자동 매치")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "자동 매치 생성"),
-            @ApiResponse(responseCode = "500", description = "Matchable member is not found")
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 매칭 가능 멤버")
     })
     @PostMapping("/match/auto")
     public ResponseEntity<ApiResult<MatchResponseDto>> autoMatch(@Valid @RequestBody(required = false) AutoMatchRequestDto autoMatchRequestDto){
@@ -72,7 +72,8 @@ public class MatchController {
 
     @Operation(summary = "수동 매치")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "수동 매치 생성")
+            @ApiResponse(responseCode = "201", description = "수동 매치 생성"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 매칭 가능 멤버")
     })
     @PostMapping("/match/manual")
     public ResponseEntity<ApiResult<?>> manualMatch(@Valid @RequestBody ManualMatchRequestDto manualMatchRequestDto){
@@ -86,7 +87,7 @@ public class MatchController {
     @Operation(summary = "매칭 취소")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "매칭 취소"),
-            @ApiResponse(responseCode = "400", description = "취소 불가능한 매치 존재 에러")
+            @ApiResponse(responseCode = "400", description = "취소 불가능한 매치")
     })
     @DeleteMapping("/match")
     public ResponseEntity<ApiResult<?>> cancelMatch(@Valid @RequestBody MatchCancelRequestDto matchCancelRequestDto){
@@ -97,7 +98,8 @@ public class MatchController {
     @Operation(summary = "매칭 다음 단계")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "매칭 다음 단계"),
-            @ApiResponse(responseCode = "400", description = "이미 완료된 매치 에러")
+            @ApiResponse(responseCode = "400", description = "이미 완료된 매치"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 매치")
     })
     @PostMapping("/match")
     public ResponseEntity<ApiResult<?>> matchStatusChange(@Valid @RequestBody List<MatchRequestDto> matchRequestDtoList){

--- a/src/main/java/com/fofo/core/domain/match/MatchFinder.java
+++ b/src/main/java/com/fofo/core/domain/match/MatchFinder.java
@@ -7,7 +7,6 @@ import com.fofo.core.storage.AddressEntity;
 import com.fofo.core.storage.MatchRepository;
 import com.fofo.core.storage.MemberEntity;
 import com.fofo.core.storage.MemberMatchEntity;
-import com.fofo.core.storage.MemberRepository;
 import com.fofo.core.support.error.CoreApiException;
 import com.fofo.core.support.error.CoreErrorType;
 import com.querydsl.core.Tuple;
@@ -26,7 +25,6 @@ import java.util.Objects;
 public class MatchFinder {
 
     private final MatchRepository matchRepository;
-    private final MemberRepository memberRepository;
 
     public List<Member> findMatchPossibleMembers() {
         List<MemberEntity> memberEntityList = matchRepository.findMatchPossibleMembers();
@@ -60,13 +58,6 @@ public class MatchFinder {
                 .toList();
         Long count = pair.getRight();
         return new PageImpl<>(matchResultList, pageRequest, count == null? 0 : count);
-    }
-
-    public MemberEntity findMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new CoreApiException(
-                        CoreErrorType.MEMBER_NOT_FOUND_ERROR)
-                );
     }
 
 }

--- a/src/main/java/com/fofo/core/domain/match/MatchManager.java
+++ b/src/main/java/com/fofo/core/domain/match/MatchManager.java
@@ -119,19 +119,18 @@ public class MatchManager {
     private Pair<Member, Member> identifyGender(Member memberA, Member memberB) {
         if(memberA.gender().equals(Gender.MAN)){
             return Pair.of(memberA, memberB);
-        } else {
-            return Pair.of(memberB, memberA);
         }
+        return Pair.of(memberB, memberA);
     }
 
     private AgeRelationType getAgeRelation(Member memberA, Member memberB) {
         if (memberA.age() > memberB.age()) {
             return AgeRelationType.OLDER;
-        } else if (memberA.age() == memberB.age()) {
-            return AgeRelationType.SAME;
-        } else {
-            return AgeRelationType.YOUNGER;
         }
+        if (memberA.age() == memberB.age()) {
+            return AgeRelationType.SAME;
+        }
+        return AgeRelationType.YOUNGER;
     }
 
     public List<Member> getSelectedMembers(List<Long> memberIdList, List<Member> matchPossibleMembers) {

--- a/src/main/java/com/fofo/core/domain/match/MatchRemover.java
+++ b/src/main/java/com/fofo/core/domain/match/MatchRemover.java
@@ -27,9 +27,8 @@ public class MatchRemover {
     private void updateCancel(MemberMatchEntity matchEntity) {
         if(!MatchingStatus.MATCHING_PENDING.equals(matchEntity.getMatchingStatus())){
             throw new CoreApiException(CoreErrorType.MATCH_UNCANCELABLE_ERROR);
-        } else {
-            matchEntity.setStatus(ActiveStatus.DELETED);
         }
+        matchEntity.setStatus(ActiveStatus.DELETED);
     }
 
 }

--- a/src/main/java/com/fofo/core/domain/match/MatchService.java
+++ b/src/main/java/com/fofo/core/domain/match/MatchService.java
@@ -1,10 +1,7 @@
 package com.fofo.core.domain.match;
 
 import com.fofo.core.controller.request.MatchRequestDto;
-import com.fofo.core.domain.ActiveStatus;
 import com.fofo.core.domain.member.Member;
-import com.fofo.core.storage.MemberEntity;
-import com.fofo.core.storage.MemberMatchEntity;
 import com.fofo.core.support.error.CoreApiException;
 import com.fofo.core.support.error.CoreErrorType;
 import lombok.RequiredArgsConstructor;
@@ -44,29 +41,8 @@ public class MatchService {
         matchRemover.removeMatch(matchIdList);
     }
 
-    @Transactional
     public void manualMatch(final Long manMemberId, final Long womanMemberId) {
-        // Member 조회 기능 개발 이후 수정 예정
-        MemberEntity manMemberEntity = matchFinder.findMember(manMemberId);
-        MemberEntity womanMemberEntity = matchFinder.findMember(womanMemberId);
-
-        // member entity -> member domain 가능해지면 입금 된 유저인지 체크 로직 추가 예정
-
-        // Member 조회 기능 개발 이후 수정 예정
-//        Match match = Match.of(
-//                man,
-//                woman,
-//                MatchingStatus.MATCHING_PENDING,
-//                ActiveStatus.CREATED
-//        );
-//        matchAppender.appendMatch(match.toEntity());
-
-        matchAppender.appendMatch(MemberMatchEntity.of(
-                manMemberId,
-                womanMemberId,
-                MatchingStatus.MATCHING_PENDING,
-                ActiveStatus.CREATED
-        ));
+        matchAppender.appendMatch(manMemberId, womanMemberId);
     }
 
     @Transactional
@@ -91,7 +67,6 @@ public class MatchService {
             } else{
                 throw new CoreApiException(CoreErrorType.ENUM_MAPPING_ERROR);
             }
-
         }
     }
 

--- a/src/main/java/com/fofo/core/storage/MatchCustomRepository.java
+++ b/src/main/java/com/fofo/core/storage/MatchCustomRepository.java
@@ -5,8 +5,10 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MatchCustomRepository {
+    Optional<MemberEntity> findMatchPossibleMemberById(Long id);
     List<MemberEntity> findMatchPossibleMembers();
     Pair<List<Tuple>, Long> findMatchResultList(Pageable pageable);
 }

--- a/src/main/java/com/fofo/core/support/error/CoreErrorCode.java
+++ b/src/main/java/com/fofo/core/support/error/CoreErrorCode.java
@@ -18,6 +18,7 @@ public enum CoreErrorCode {
     MATE500,
     MATE501,
     MATE502,
-    MATE503
+    MATE503,
+    MATE504
     ;
 }

--- a/src/main/java/com/fofo/core/support/error/CoreErrorType.java
+++ b/src/main/java/com/fofo/core/support/error/CoreErrorType.java
@@ -28,7 +28,7 @@ public enum CoreErrorType {
     //Match 관련 에러
     MATCH_ALREADY_COMPLETED_ERROR(HttpStatus.BAD_REQUEST, CoreErrorCode.MATE500, "Match is already COMPLETED.", LogLevel.ERROR),
     MATCH_UNCANCELABLE_ERROR(HttpStatus.BAD_REQUEST, CoreErrorCode.MATE501, "UnCancelable Match exists", LogLevel.ERROR),
-    MATCHABLE_MEMBER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, CoreErrorCode.MATE502, "Matchable member is not found", LogLevel.ERROR),
+    MATCHABLE_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, CoreErrorCode.MATE502, "Matchable member is not found", LogLevel.ERROR),
     MATCH_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, CoreErrorCode.MATE503, "Match Not found", LogLevel.ERROR);
 
     private final HttpStatus status;

--- a/src/main/java/com/fofo/core/support/error/CoreErrorType.java
+++ b/src/main/java/com/fofo/core/support/error/CoreErrorType.java
@@ -29,7 +29,8 @@ public enum CoreErrorType {
     MATCH_ALREADY_COMPLETED_ERROR(HttpStatus.BAD_REQUEST, CoreErrorCode.MATE500, "Match is already COMPLETED.", LogLevel.ERROR),
     MATCH_UNCANCELABLE_ERROR(HttpStatus.BAD_REQUEST, CoreErrorCode.MATE501, "UnCancelable Match exists", LogLevel.ERROR),
     MATCHABLE_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, CoreErrorCode.MATE502, "Matchable member is not found", LogLevel.ERROR),
-    MATCH_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, CoreErrorCode.MATE503, "Match Not found", LogLevel.ERROR);
+    MATCH_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, CoreErrorCode.MATE503, "Match Not found", LogLevel.ERROR),
+    MATCH_SAME_GENDER_ERROR(HttpStatus.BAD_REQUEST, CoreErrorCode.MATE504, "Members of Match have same gender", LogLevel.ERROR);
 
     private final HttpStatus status;
 


### PR DESCRIPTION
- 수동 매치 구현
- `MATCHABLE_MEMBER_NOT_FOUND` 에러 코드 404로 변경
- 매치 같은 성별 에러 타입 추가
- `@Transactional` 구현레이어에 오도록 구현
- 다른 메소드는 더 고민이 필요함..

This closes #32 